### PR TITLE
Fix mirai classification and TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ A curated collection of AI agent use cases across industries, showcasing practic
 
 ## 📋 Table of Contents
 
-- [Introduction](#introduction)
+- [Introduction](#-introduction)
 - [Industry Usecase](#-industry-usecase-mindmap)
-- [Use Case Table](#use-case-table)
+- [Use Case Table](#-use-case-table)
 - [Framework Wise UseCase](#framework-wise-usecases)
   - [CrewAI UseCase](#framework-name-crewai)
   - [AutoGen UseCase](#framework-name-autogen)
   - [Agno UseCase](#framework-name-agno)
   - [Langgraph UseCase](#framework-name-langgraph)
-- [Contributing](#contributing)
-- [License](#license)
+- [Contributing](#-contributing)
+- [License](#-license)
 
 ---
 


### PR DESCRIPTION
- Reclassify MIRAI from **Energy** to **Geopolitics**.
- Update description to: “Evaluates LLM agents for international relations forecasting.”
- Fix  Table of Contents anchors.

Why:
MIRAI benchmarks LLM agents for forecasting international events (news + GDELT), not energy demand.

Refs:
- Repo: https://github.com/yecchen/MIRAI
- Paper (arXiv): https://arxiv.org/abs/2407.01231
