### PR TITLE
Add Chitin: On-chain soul identity for AI agents on Base L2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Whether you're a developer, researcher, or business enthusiast, this repository 
 | **Vibe Hacking Agent**                | Cybersecurity    | Autonomous Multi-Agent Based Red Team Testing Service.   | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/PurpleAILAB/Decepticon) |
 | **MediSuite-Ai-Agent**  | Health insurance  | A medical ai agent that helps automating the process of hospitals / insurance claiming workflow. | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/MahmoudRabea13/MediSuite-Ai-Agent)                                         | 
 | **Lina-Egyptian-Medical-Chatbot**  | Health insurance  | A medical ai agent that helps automating the process of hospitals / insurance claiming workflow. | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/MahmoudRabea13/MediSuite-Ai-Agent)                                         |
+| **Chitin**  | Web3 Agents  | On-chain soul identity, certificates, and governance for AI agents on Base L2. Issues Soulbound Tokens as verifiable birth certificates with ERC-8004 agent passports. | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/Tiida-Tech/chitin-contracts)                                         |
 
 ## Framework wise Usecases
 


### PR DESCRIPTION
Adds [Chitin](https://chitin.id) to the project list.

Chitin provides on-chain soul identity for AI agents on Base L2:
- Soulbound Tokens (EIP-5192) as permanent birth certificates
- ERC-8004 agent passports for cross-chain identity
- W3C DID resolution, on-chain certificates, governance voting
- Open source smart contracts (MIT): https://github.com/Tiida-Tech/chitin-contracts
- MCP server: https://www.npmjs.com/package/chitin-mcp-server

Live on Base Mainnet.