### PR TITLE
docs: remove merge conflict markers from contribution guide

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -167,8 +167,4 @@ By contributing, you agree to the project's Code of Conduct. Be respectful, cons
 
 ---
 
-<<<<<<< HEAD
 Thank you for contributing to 500-AI-Agents-Projects — your examples, templates, and tools make the agent community stronger and more reproducible.
-=======
-Thank you for contributing to 500-AI-Agents-Projects — your examples, templates, and tools make the agent community stronger and more reproducible.
->>>>>>> f5a092190b226a6723718d7680aa689f1d2b64bc


### PR DESCRIPTION
## Summary
- remove leftover git merge conflict markers from `CONTRIBUTION.md`
- keep the intended thank-you line intact

## Why
The contribution guide currently renders raw conflict markers at the end of the document, which is confusing for contributors and makes the repo look accidentally broken.

## Verification
- confirmed the conflict markers were present in `CONTRIBUTION.md` before the change
- searched the repo after the patch to ensure no conflict markers remain