### PR TITLE
Add Competitor Analysis Agent to Industry Use Cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Choosing a framework? Here's when to use each:
 | **Citadel** | Software Development | Orchestrates Claude Code agent fleets with lifecycle hooks, skills, campaign management, and postmortem-driven architecture | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/SethGammon/Citadel) |
 | **MediSuite-AI-Agent** | Health Insurance | Automates hospital / insurance claiming workflow | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/ahmedmansour5/MediSuite-Ai-Agent) |
 | **Lina Egyptian Medical Chatbot** | Healthcare | Egyptian medical assistant chatbot | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/dina-khalid/Lina-Egyptian-Medical-Chatbot) |
+| **Competitor Analysis Agent** | Competitive Intelligence | Python agent that scrapes competitor sites and chains search, news, and research APIs to generate competitive intelligence reports | [![Guide](https://img.shields.io/badge/Guide-Tutorial-blue)](https://superhighway.walls.sh/guides/competitor-analysis-agent) |
 
 ---
 


### PR DESCRIPTION
Adds an external-link row to the **Industry Use Cases** table (as encouraged in the Contributing section: "Add an external link — add a row to the industry or framework tables").

| Use Case | Industry | Description | Code |
|---|---|---|---|
| **Competitor Analysis Agent** | Competitive Intelligence | Python agent that scrapes competitor sites and chains search, news, and research APIs to generate competitive intelligence reports | Guide link |

The linked guide is a complete Python walkthrough showing how to build a multi-step agent that scrapes competitor websites, pulls fresh news, and runs deep research to produce a structured competitive-intelligence report. Adds a Competitive Intelligence industry vertical not yet represented in the table.

## Summary by Sourcery

New Features:
- Introduce a Competitor Analysis Agent example under a new Competitive Intelligence industry category, linking to an external tutorial guide.