### PR TITLE
ci: add markdown linting scoped to real defects

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,27 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.md'
+      - '.markdownlint-cli2.jsonc'
+  pull_request:
+    paths:
+      - '**.md'
+      - '.markdownlint-cli2.jsonc'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: ''

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,25 @@
+{
+  // Scoped to the docs contributors actually edit. The course content and
+  // internal notes are left alone on purpose.
+  "globs": ["README.md", "CONTRIBUTION.md", "SECURITY.md", "CODE_OF_CONDUCT.md", "agents/**/*.md"],
+
+  "config": {
+    // Cosmetic rules are off on purpose - this repo is tables and badges, and
+    // reformatting 400 lines to satisfy a linter buys nothing.
+    "MD013": false, // line length - every table row exceeds 80 chars
+    "MD022": false, // blank lines around headings
+    "MD031": false, // blank lines around fences
+    "MD032": false, // blank lines around lists
+    "MD033": false, // inline HTML - the badge and centering blocks need it
+    "MD034": false, // bare URLs - contact emails are intentional
+    "MD036": false, // emphasis as heading - deliberate in the AutoGen subsections
+    "MD040": false, // fence language - sample-output blocks have none by design
+    "MD041": false, // first line must be a heading
+    "MD060": false, // table pipe spacing
+
+    // What stays on is the set that catches real defects in contributor PRs:
+    // MD011 reversed link syntax, MD042 empty links, MD051 broken heading
+    // anchors, MD039 spaces inside link text, MD024 duplicate headings.
+    "MD024": { "siblings_only": true }
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up on #15, which proposed markdown linting. That PR went stale and I closed it, but the gap was real - `main` only has a link checker, nothing catching malformed markup.

## Why the default ruleset is not usable here

Running stock markdownlint against this repo produces ~500 errors, essentially all of them false alarms:

- **MD013** (80-char lines) flags every single table row
- **MD033** (no inline HTML) flags every badge block and every `<div align="center">`
- **MD060** (table pipe spacing) flags the compact `|---|---|` style used throughout

Turning those on would mean reformatting 400 lines of working markdown to satisfy a tool. Not worth it.

## What this does instead

Cosmetic rules off, correctness rules on:

| Rule | Catches |
|---|---|
| MD011 | Reversed link syntax — `(text)[url]` |
| MD042 | Empty links — `[![GitHub]()]()` |
| MD051 | Broken heading anchors |
| MD039 | Spaces inside link text |
| MD024 | Duplicate headings |

This is not hypothetical. PR #27's diff shipped a malformed badge:

```markdown
| [![Github](https://github.com/crewAIInc/crewAI-examples/tree/main/integrations/CrewAI-LangGraph)          |
```

Missing image URL, missing closing bracket. It was caught by reading the diff by hand. MD042 catches it automatically.

## Verification

- Built a fixture reproducing #27's badge plus an empty link and a bad anchor — **all three caught**
- Existing 25 markdown files pass **clean, zero changes required**
- Config and globs live in one file rather than two

Scoped to `README.md`, `CONTRIBUTION.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, and `agents/**/*.md`. Course content and internal notes are deliberately excluded.

## Summary by Sourcery

Introduce automated markdown linting in CI using markdownlint-cli2 with repository-specific configuration.

Build:
- Add a markdownlint-cli2 configuration file to control which markdown rules and paths are enforced.

CI:
- Add a GitHub Actions workflow to run markdownlint on markdown files for pushes, pull requests, and manual runs.