### PR TITLE
ci: auto-manage stale pull requests and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,66 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # Mondays, 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Deliberately generous. Contributors here are volunteers adding a row
+          # to a catalog, not staff. The goal is to close what has genuinely been
+          # abandoned, not to rush anyone.
+          days-before-stale: 60
+          days-before-close: 21
+
+          stale-pr-message: >
+            This PR has had no activity for 60 days, so I'm marking it stale.
+
+
+            If you're still interested, just push a commit or leave a comment and
+            I'll take the label off. Rebasing onto current `main` is usually all
+            it needs — this README changes often and older branches stop merging
+            cleanly.
+
+
+            If I don't hear anything in 21 days it'll close automatically. That's
+            not a rejection and you can reopen it any time.
+
+          close-pr-message: >
+            Closing this after 81 days without activity.
+
+
+            No hard feelings and nothing personal — I'd rather keep the queue
+            honest than leave PRs sitting open indefinitely with no answer.
+            Reopen it whenever you like, or open a fresh one against current
+            `main`.
+
+          stale-issue-message: >
+            This issue has had no activity for 60 days, so I'm marking it stale.
+            Comment if it's still relevant and I'll keep it open.
+
+          close-issue-message: >
+            Closing after 81 days without activity. Reopen if it's still an issue.
+
+          stale-pr-label: stale
+          stale-issue-label: stale
+
+          # Anything I've explicitly triaged is never auto-closed.
+          exempt-pr-labels: 'pinned,security,in progress,awaiting-maintainer'
+          exempt-issue-labels: 'pinned,security,in progress,awaiting-maintainer'
+
+          # Removing the label on new activity is the point - it lets a
+          # contributor rescue their own PR without needing me.
+          remove-stale-when-updated: true
+
+          # Small batches so a first run cannot mass-close the backlog.
+          operations-per-run: 30
+          ascending: true


### PR DESCRIPTION
## Why

The queue hit **53 open PRs**, with the oldest untouched for **eight months**. That did not happen because submissions were bad — it happened because nothing ever closed anything. Contributors got no answer, and the queue stopped being reviewable.

This is the fix that prevents it recurring.

## Policy

| | |
|---|---|
| Stale after | 60 days of no activity |
| Closed after | 21 further days (81 total) |
| Any activity | removes the label automatically |

Deliberately generous. Contributors here are volunteers adding a row to a catalog, not staff. The goal is closing what is genuinely abandoned — not rushing anyone.

## Safety rails

- **`operations-per-run: 30` + `ascending: true`** — the first run works through the oldest items in batches rather than mass-closing 28 open PRs in one pass
- **`remove-stale-when-updated: true`** — a contributor rescues their own PR by pushing a commit, no maintainer action needed
- **Exempt labels** — `pinned`, `security`, `in progress`, `awaiting-maintainer`. Anything explicitly triaged is never auto-closed
- Runs weekly on a schedule, plus `workflow_dispatch` for manual runs

## Messages

Written to be non-punitive. The close message says plainly that it is not a rejection and the PR can be reopened at any time.

## Summary by Sourcery

CI:
- Add a scheduled stale management workflow that labels and auto-closes inactive issues and pull requests with contributor-friendly messaging and safety limits.