### PR TITLE
docs: add Refund Resolution Agent to Industry Use Cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Choosing a framework? Here's when to use each:
 | **Lina Egyptian Medical Chatbot** | Healthcare | Egyptian medical assistant chatbot | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/dina-khalid/Lina-Egyptian-Medical-Chatbot) |
 | **NextRole (AI Career Assistant)** | Human Resources | Tailors a resume to a job description and generates interview prep plus a day-of battlecard via a multi-agent system | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/tam159/next-role) |
 | **PII Sanitization Agent** | Privacy/Compliance | Redacts PII (emails, phones, national IDs, bank accounts, API keys) from text before it reaches an LLM; fail-closed, multilingual, on-chain proof via TrustBoost | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer) |
+| **Refund Resolution Agent** | Customer Service | Resolves refund tickets end to end with irreversible tools, verifying identity before money moves and escalating where policy requires | [![GitHub](https://img.shields.io/badge/Code-GitHub-black?logo=github)](https://github.com/immu4989/awesome-agentic-usecases/tree/main/customer-support/refund-resolution-agent) |
 
 ---
 


### PR DESCRIPTION
Adds one row to the Industry Use Cases table, following the existing format and placed at the end of the table.

**Why this one:** Customer Service currently has a single entry (a 24/7 chatbot). This agent is a different shape — it *carries out* the resolution rather than answering questions about it, using tools that move money and dispatch goods, with identity verification as a hard prerequisite before anything irreversible happens.

**What it ships with.** It comes from an Apache-2.0 repository where a use case is only included if it arrives with the evidence that it works, rather than a single demo run:

- an eval set of 30 scenarios with programmatic ground truth generated from a committed seed, so scoring is exact rather than judged by another model
- cost per run in dollars, computed from measured token usage
- results across 3 repeated runs per model with bootstrap confidence intervals, because agent runs are stochastic
- failure modes observed in committed runs, each with a reproducing scenario id

**Reproducing it costs nothing.** It runs with no API key at all on a deterministic mock backend, and the real-model results were produced on provider free tiers.

Happy to adjust the wording, the category, or the placement if you'd prefer it elsewhere.

## Summary by Sourcery

Documentation:
- Document the Refund Resolution Agent as an additional customer service use case in the Industry Use Cases table.